### PR TITLE
build(workflows): support automatic build and on-demand release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,43 +1,112 @@
-name: Build Chrome++
+name: Build
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (SemVer)'
+        required: true # WIP: not required in alpha build
 
 jobs:
   build:
     strategy:
       matrix:
-        include: [
-            { name: Chrome++_x86, arch: x86 },
-            { name: Chrome++_x64, arch: x64 },
-            { name: Chrome++_arm64, arch: arm64 }
-        ]
+        include:
+          - name: build_x86
+            arch: x86
+          - name: build_x64
+            arch: x64
+          - name: build_arm64
+            arch: arm64
 
     name: ${{ matrix.name }}
-
     runs-on: windows-latest
 
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v4
-      with:
-        submodules: 'true'
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
 
-    - name: Setup VC-LTL
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nuget install VC-LTL
+      - name: Update version.h
+        shell: bash
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          sed -i 's/#define RELEASE_VER_MAIN .*/#define RELEASE_VER_MAIN '"$MAJOR"'/' src/version.h
+          sed -i 's/#define RELEASE_VER_SUB .*/#define RELEASE_VER_SUB '"$MINOR"'/' src/version.h
+          sed -i 's/#define RELEASE_VER_FIX .*/#define RELEASE_VER_FIX '"$PATCH"'/' src/version.h
 
-    - name: Setup Xmake
-      uses: xmake-io/github-action-setup-xmake@v1
+      - name: Setup VC-LTL
+        run: nuget install VC-LTL
 
-    - name: Configure Xmake
-      run: xmake f -a ${{ matrix.arch }}
+      - name: Setup Xmake
+        uses: xmake-io/github-action-setup-xmake@v1
 
-    - name: Build Chrome++
-      run: xmake
+      - name: Configure Xmake
+        run: xmake f -a ${{ matrix.arch }}
 
-    - name: Upload DLL
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ matrix.name }}
-        path: build/release
+      - name: Build Chrome++
+        run: xmake
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_${{ matrix.arch }}
+          path: build/release/*
+
+  create_pr:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Git Configurations
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b release
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build_artifacts
+
+      - name: Update SetDll
+        run: |
+          mv build_artifacts/build_x86/version.dll chrome++32.dll
+          mv build_artifacts/build_x64/version.dll chrome++64.dll
+          cp chrome++32.dll setdll/
+          cp chrome++64.dll setdll/
+          cp src/chrome++.ini setdll/
+          rm setdll/setdll.7z || true
+          cd setdll
+          7z a ../setdll.7z ./*
+          cd ..
+          mv setdll.7z setdll/
+
+          git add setdll/
+          git commit -m "Update setdll binaries"
+          git push origin release --force
+
+      - name: Update version.h
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          sed -i 's/#define RELEASE_VER_MAIN .*/#define RELEASE_VER_MAIN '"$MAJOR"'/' src/version.h
+          sed -i 's/#define RELEASE_VER_SUB .*/#define RELEASE_VER_SUB '"$MINOR"'/' src/version.h
+          sed -i 's/#define RELEASE_VER_FIX .*/#define RELEASE_VER_FIX '"$PATCH"'/' src/version.h
+          git add src/version.h
+          git commit -m "Bump version"
+
+      - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          git push origin release
+          gh pr create --base main --head release --title "build(release): bump version to ${{ github.event.inputs.version }}" --body "Bump version to ${{ github.event.inputs.version }}"
+
+      - name: Output Run ID
+        run: echo "RUN_ID=${{ github.run_id }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,23 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".clang-format"
+      - ".gitignore"
+      - "README.md"
+      - "README_CN.md"
+      - "LICENSE"
+      - "setdll/**"
+      - "src/version.h"
+      - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
     inputs:
       version:
         description: 'Release version (SemVer)'
-        required: true # WIP: not required in alpha build
+        required: true
 
 jobs:
   build:
@@ -31,11 +43,19 @@ jobs:
       - name: Update version.h
         shell: bash
         run: |
-          VERSION="${{ github.event.inputs.version }}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          sed -i 's/#define RELEASE_VER_MAIN .*/#define RELEASE_VER_MAIN '"$MAJOR"'/' src/version.h
-          sed -i 's/#define RELEASE_VER_SUB .*/#define RELEASE_VER_SUB '"$MINOR"'/' src/version.h
-          sed -i 's/#define RELEASE_VER_FIX .*/#define RELEASE_VER_FIX '"$PATCH"'/' src/version.h
+          if [ "${{ github.event_name }}" == "push" ]; then
+            COMMIT_HASH=$(git rev-parse --short HEAD)
+            VERSION="alpha-${COMMIT_HASH}"
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            sed -i '/#define RELEASE_VER_STR/,/TOSTRING(RELEASE_VER_FIX)/c\#define RELEASE_VER_STR "'"$VERSION"'"' src/version.h
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+            sed -i 's/#define RELEASE_VER_MAIN .*/#define RELEASE_VER_MAIN '"$MAJOR"'/' src/version.h
+            sed -i 's/#define RELEASE_VER_SUB .*/#define RELEASE_VER_SUB '"$MINOR"'/' src/version.h 
+            sed -i 's/#define RELEASE_VER_FIX .*/#define RELEASE_VER_FIX '"$PATCH"'/' src/version.h
+          fi
 
       - name: Setup VC-LTL
         run: nuget install VC-LTL
@@ -52,12 +72,13 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build_${{ matrix.arch }}
+          name: version-${{ matrix.arch }}-${{ env.VERSION }}
           path: build/release/*
 
   create_pr:
     needs: build
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout repository
@@ -74,32 +95,36 @@ jobs:
         with:
           path: build_artifacts
 
-      - name: Update SetDll
-        run: |
-          mv build_artifacts/build_x86/version.dll chrome++32.dll
-          mv build_artifacts/build_x64/version.dll chrome++64.dll
-          cp chrome++32.dll setdll/
-          cp chrome++64.dll setdll/
-          cp src/chrome++.ini setdll/
-          rm setdll/setdll.7z || true
-          cd setdll
-          7z a ../setdll.7z ./*
-          cd ..
-          mv setdll.7z setdll/
-
-          git add setdll/
-          git commit -m "Update setdll binaries"
-          git push origin release --force
+      - name: Install 7zz
+        run: sudo apt install 7zip
 
       - name: Update version.h
         run: |
           VERSION="${{ github.event.inputs.version }}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
           sed -i 's/#define RELEASE_VER_MAIN .*/#define RELEASE_VER_MAIN '"$MAJOR"'/' src/version.h
           sed -i 's/#define RELEASE_VER_SUB .*/#define RELEASE_VER_SUB '"$MINOR"'/' src/version.h
           sed -i 's/#define RELEASE_VER_FIX .*/#define RELEASE_VER_FIX '"$PATCH"'/' src/version.h
           git add src/version.h
           git commit -m "Bump version"
+
+      - name: Update SetDll
+        run: |
+          mv build_artifacts/version-x86-${{ env.VERSION }}/version.dll chrome++32.dll
+          mv build_artifacts/version-x64-${{ env.VERSION }}/version.dll chrome++64.dll
+          cp chrome++32.dll setdll/
+          cp chrome++64.dll setdll/
+          cp src/chrome++.ini setdll/
+          rm setdll/setdll.7z || true
+          cd setdll
+          7zz a -mx=9 -ms=on -m0=lzma2 -mmt=on ../setdll.7z ./*
+          cd ..
+          mv setdll.7z setdll/
+
+          git add setdll/
+          git commit -m "Update setdll binaries"
+          git push origin release --force
 
       - name: Create Pull Request
         env:

--- a/.github/workflows/genReleaseNote.sh
+++ b/.github/workflows/genReleaseNote.sh
@@ -14,7 +14,7 @@ while getopts "v:" opt; do
 done
 
 if [ -z "$version_range" ]; then
-  echo "Please provide the version range using -v option. Example: ./genReleaseNote.sh -v 1.14.1...1.14.2"
+  echo "Please provide the version range using -v option. Example: chmod +x genReleaseNote.sh && ./genReleaseNote.sh -v 1.0.0..HEAD" >&2
   exit 1
 fi
 

--- a/.github/workflows/genReleaseNote.sh
+++ b/.github/workflows/genReleaseNote.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# From https://github.com/MetaCubeX/mihomo/blob/82517e6ba8059339287911af899ffdffca6a4044/.github/genReleaseNote.sh
+
+while getopts "v:" opt; do
+  case $opt in
+    v)
+      version_range=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$version_range" ]; then
+  echo "Please provide the version range using -v option. Example: ./genReleaseNote.sh -v 1.14.1...1.14.2"
+  exit 1
+fi
+
+new_commits=$(git log --pretty=format:"* %h %s by @%an" --grep="^feat" -i $version_range | sort -f | uniq)
+if [ -n "$new_commits" ]; then
+  echo "## New" >> release.md
+  echo "$new_commits" >> release.md
+  echo "" >> release.md
+fi
+
+fix_commits=$(git log --pretty=format:"* %h %s by @%an" --grep="^fix" -i $version_range | sort -f | uniq)
+if [ -n "$fix_commits" ]; then
+  echo "## Fix" >> release.md
+  echo "$fix_commits" >> release.md
+  echo "" >> release.md
+fi
+
+maint_commits=$(git log --pretty=format:"* %h %s by @%an" --grep="^chore\|^docs\|^refactor" -i $version_range | sort -f | uniq)
+if [ -n "$maint_commits" ]; then
+  echo "## Maintenance" >> release.md
+  echo "$maint_commits" >> release.md
+  echo "" >> release.md
+fi
+
+echo "**Full Changelog**: https://github.com/KdeInit/chrome_plus/compare/$version_range" >> release.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/version.h'
+
+env:
+  GH_TOKEN: ${{ secrets.TOKEN }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Get Last Tag
+        id: get_last_tag
+        run: |
+          LAST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) || echo "0.0.0")
+          echo "last_tag=$LAST_TAG" >> $GITHUB_ENV
+
+      - name: Get Version from version.h
+        run: |
+          MAJOR=$(grep '#define RELEASE_VER_MAIN' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define RELEASE_VER_SUB' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define RELEASE_VER_FIX' src/version.h | awk '{print $3}')
+          VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Create Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ env.VERSION }}" -m "Release ${{ env.VERSION }}"
+
+      - name: Generate Release Notes
+        run: |
+          chmod +x .github/genReleaseNote.sh
+          .github/genReleaseNote.sh -v ${{ env.last_tag }}...${{ env.VERSION }}
+
+      - name: Get Latest Workflow Run
+        id: workflow
+        run: |
+          RUN_ID=$(gh api repos/${{ github.repository }}/actions/workflows/build.yml/runs \
+            --jq '.workflow_runs[0].id')
+          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build_artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.workflow.outputs.run_id }}
+
+      - name: Package All Artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts/x86/{App,Data,Cache}
+          mkdir -p artifacts/x64/{App,Data,Cache}
+          mkdir -p artifacts/arm64/{App,Data,Cache}
+          cp -r build_artifacts/build_x86/* artifacts/x86/App/
+          cp -r build_artifacts/build_x64/* artifacts/x64/App/
+          cp -r build_artifacts/build_arm64/* artifacts/arm64/App/
+          cd artifacts
+          7z a ../Chrome++_v${{ env.VERSION }}_x86_x64_arm64.7z *
+          cd ..
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: Chrome++_v${{ env.VERSION }}_x86_x64_arm64.7z
+          body_path: release.md
+          tag_name: ${{ env.VERSION }}
+          name: ${{ env.VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
     paths:
       - 'src/version.h'
 
-env:
-  GH_TOKEN: ${{ secrets.TOKEN }}
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -22,10 +19,9 @@ jobs:
           fetch-depth: 0
 
       - name: Get Last Tag
-        id: get_last_tag
         run: |
           LAST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) || echo "0.0.0")
-          echo "last_tag=$LAST_TAG" >> $GITHUB_ENV
+          echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
 
       - name: Get Version from version.h
         run: |
@@ -39,12 +35,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ env.VERSION }}" -m "Release ${{ env.VERSION }}"
+          git tag -a "${{ env.VERSION }}" -m "${{ env.VERSION }}"
 
       - name: Generate Release Notes
         run: |
           chmod +x .github/genReleaseNote.sh
-          .github/genReleaseNote.sh -v ${{ env.last_tag }}...${{ env.VERSION }}
+          .github/genReleaseNote.sh -v ${{ env.LAST_TAG }}...${{ env.VERSION }}
 
       - name: Get Latest Workflow Run
         id: workflow
@@ -62,17 +58,19 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ steps.workflow.outputs.run_id }}
 
+      - name: Install 7zz
+        run: sudo apt install 7zip
+
       - name: Package All Artifacts
-        shell: bash
         run: |
           mkdir -p artifacts/x86/{App,Data,Cache}
           mkdir -p artifacts/x64/{App,Data,Cache}
           mkdir -p artifacts/arm64/{App,Data,Cache}
-          cp -r build_artifacts/build_x86/* artifacts/x86/App/
-          cp -r build_artifacts/build_x64/* artifacts/x64/App/
-          cp -r build_artifacts/build_arm64/* artifacts/arm64/App/
+          cp -r build_artifacts/version-x86-${{ env.VERSION }}/* artifacts/x86/App/
+          cp -r build_artifacts/version-x64-${{ env.VERSION }}/* artifacts/x64/App/
+          cp -r build_artifacts/version-arm64-${{ env.VERSION }}/* artifacts/arm64/App/
           cd artifacts
-          7z a ../Chrome++_v${{ env.VERSION }}_x86_x64_arm64.7z *
+          7zz a -mx=9 -m0=lzma2 -mmt=on ../Chrome++_v${{ env.VERSION }}_x86_x64_arm64.7z *
           cd ..
 
       - name: Create Release


### PR DESCRIPTION
This commit supports automatically building an alpha version with the latest short hash and uploading it to Artifacts when there is a push on the main branch. It also supports manually running `build.yml`, which will require entering a version number that complies with semantic versioning. It will automatically build and create a PR that includes a commit updating the version number in `version.h` and submits the corresponding binary files to `setdll`. When this PR is merged, since `version.h` is updated, it will automatically trigger the generation of release notes based on the latest version number and complete a series of release operations.