### PR TITLE
fix: make arrow-selected omnibox suggestions open in new tab

### DIFF
--- a/src/iaccessible.cc
+++ b/src/iaccessible.cc
@@ -552,7 +552,7 @@ BookmarkState CheckBookmarkState(HWND hwnd, POINT pt) {
   return state;
 }
 
-bool IsOmniboxFocus(const NodePtr& top) {
+[[maybe_unused]] bool IsOmniboxFocus(const NodePtr& top) {
   if (!top) {
     return false;
   }
@@ -583,6 +583,39 @@ bool IsOmniboxFocus(const NodePtr& top) {
   };
   TraversalAccessible(top, find_toolbar, false);
   return is_focused;
+}
+
+bool IsOmniboxDropdownSelected(const NodePtr& root) {
+  if (!root) {
+    return false;
+  }
+
+  bool found = false;
+  auto find_selected_suggestion = [&](this auto&& self,
+                                      const NodePtr& node) -> bool {
+    if ((GetAccessibleRole(node) == ROLE_SYSTEM_LISTITEM) &&
+        (GetAccessibleState(node) & STATE_SYSTEM_SELECTED)) {
+      // Mar 31, 2026 - Chrome 146.0.7680.165
+      //   root
+      //   └─ ...
+      //      └─ LIST (0x21, expanded)
+      //         └─ PANE (0x10)
+      //            └─ LISTITEM (0x22, selected)
+      NodePtr parent = GetParentElement(node);
+      while (parent) {
+        if ((GetAccessibleRole(parent) == ROLE_SYSTEM_LIST) &&
+            (GetAccessibleState(parent) & STATE_SYSTEM_EXPANDED)) {
+          found = true;
+          return true;
+        }
+        parent = GetParentElement(parent);
+      }
+    }
+    TraversalAccessible(node, self, false);
+    return found;
+  };
+  TraversalAccessible(root, find_selected_suggestion, false);
+  return found;
 }
 
 // Whether the mouse is on the close button of a tab.

--- a/src/iaccessible.h
+++ b/src/iaccessible.h
@@ -22,7 +22,8 @@ bool IsOnTheTabBar(const NodePtr& top, POINT pt);
 bool IsOnNewTab(const NodePtr& top);
 TabInfo GetTabInfo(const NodePtr& top, POINT pt, bool need_count);
 BookmarkState CheckBookmarkState(HWND hwnd, POINT pt);
-bool IsOmniboxFocus(const NodePtr& top);
+[[maybe_unused]] bool IsOmniboxFocus(const NodePtr& top);
+bool IsOmniboxDropdownSelected(const NodePtr& root);
 bool IsOnCloseButton(const NodePtr& top, POINT pt);
 bool IsOnFindBarPane(POINT pt);
 

--- a/src/tabbookmark.cc
+++ b/src/tabbookmark.cc
@@ -401,20 +401,26 @@ bool HandleKeepTab(WPARAM wParam) {
 
 bool HandleOpenUrlNewTab(WPARAM wParam) {
   int mode = config.GetOpenUrlNewTabMode();
-  if (!(mode != 0 && wParam == VK_RETURN && !IsKeyPressed(VK_MENU))) {
+  if (mode == 0 || wParam != VK_RETURN || IsKeyPressed(VK_MENU)) {
     return false;
   }
 
   NodePtr top_container_view = GetTopContainerView(GetForegroundWindow());
-  if (IsOmniboxFocus(top_container_view) && !IsOnNewTab(top_container_view)) {
-    if (mode == 1) {
-      SendKey(VK_MENU, VK_RETURN);
-    } else if (mode == 2) {
-      SendKey(VK_SHIFT, VK_MENU, VK_RETURN);
-    }
-    return true;
+  if (IsOnNewTab(top_container_view)) {
+    return false;
   }
-  return false;
+
+  NodePtr chrome_widget = GetChromeWidgetWin(GetFocus());
+  if (!IsOmniboxDropdownSelected(chrome_widget)) {
+    return false;
+  }
+
+  if (mode == 1) {
+    SendKey(VK_MENU, VK_RETURN);
+  } else if (mode == 2) {
+    SendKey(VK_SHIFT, VK_MENU, VK_RETURN);
+  }
+  return true;
 }
 
 // Keyboard handler for tab and bookmark operations


### PR DESCRIPTION
The suggestions in the omnibox dropdown is not shown in
`top_container_view`, so we need to traversal from browser_view to make
`open_url_new_tab` work.

Fix #236.