### PR TITLE
fix: avoid UIA teardown hang on browser exit

### DIFF
--- a/src/uia.cc
+++ b/src/uia.cc
@@ -87,8 +87,13 @@ struct UiaSession {
 };
 
 UiaSession& GetThreadLocalUiaSession() {
-  thread_local UiaSession session;
-  return session;
+  // UI Automation proxies can block while being released from Chrome's UI
+  // thread during process teardown. Keep the apartment-bound session isolated
+  // per thread, but intentionally give it process lifetime so no COM cleanup
+  // runs from the injected DLL's TLS teardown path. Windows reclaims the
+  // allocation and COM references when the process exits.
+  thread_local UiaSession* session = new UiaSession;
+  return *session;
 }
 
 bool CreateClassCondition(const ComPtr<IUIAutomation>& automation,


### PR DESCRIPTION
## Summary

Prevent Chrome from remaining in the background after all browser windows are closed.

## Root cause

The thread-local `UiaSession` destructor releases UI Automation proxies during the injected DLL's TLS teardown.

When this cleanup runs on Chrome's UI thread, releasing these apartment-bound COM proxies can block indefinitely during process shutdown, leaving Chrome processes in the background.

## Regression

The regression was introduced by commit 8b22f8d, which migrated tab and
bookmark handling from IA2 to UI Automation.

On Chrome 150.0.7871.129, the parent commit f7d23b3 exited normally after
the affected interaction, while 8b22f8d still had Chrome processes running
after 15 seconds.

The first affected prerelease was 1.16.0-alpha.1, and the first affected
stable release was 1.16.0.

## Fix

Keep the `UiaSession` isolated per thread, but intentionally give it process lifetime by storing it behind a thread-local pointer.

This prevents UIA and COM cleanup from running during the injected DLL's TLS teardown. The operating system reclaims the process resources when Chrome terminates.

## Trade-off

This intentionally skips per-thread UIA and COM teardown.

The UIA session is currently instantiated only on Chrome's browser UI thread through thread-specific input hooks, so the retained state is bounded to one session per browser process.

This project loads `version.dll` for the lifetime of the browser process and does not support unloading it while Chrome is still running.

## Testing

- Built successfully with `xmake build -y`.
- A/B tested with a clean x64 Chrome 150.0.7871.129 installation.
- Used a fresh user-data directory, disabled extensions and component updates, and applied the minimal configuration from #271.
- Explicitly initialized the UIA path by opening two tabs and double-clicking one tab before closing the browser.
- With Chrome++ 1.18.0, Chrome processes were still present after 15 seconds.
- With this patch, Chrome exited completely in 226 ms, 244 ms, and 232 ms across three successful runs.
- Also verified the patch with clean Chrome 150.0.7871.125; Chrome exited completely in 254 ms after the same UIA trigger.

Related to #271.