### PR TITLE
[Grok Build] fix: stop double-click tab close from breaking follow-up gestures

### DIFF
--- a/src/tabbookmark.cc
+++ b/src/tabbookmark.cc
@@ -243,6 +243,12 @@ bool HandleDoubleClick(const MOUSEHOOKSTRUCT* pmouse) {
 
   const POINT pt = pmouse->pt;
   HWND hwnd = WindowFromPoint(pt);
+  // Commands target the browser frame; child HWNDs under the cursor are common.
+  if (hwnd) {
+    if (const HWND root = GetAncestor(hwnd, GA_ROOT)) {
+      hwnd = root;
+    }
+  }
   const auto hit = FindTabHitResult(pt, config.IsKeepLastTab(), true);
   if (!hit || hit->on_close_button) {
     return false;
@@ -375,33 +381,50 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
   PMOUSEHOOKSTRUCT pmouse = reinterpret_cast<PMOUSEHOOKSTRUCT>(lParam);
 
   static bool wheel_tab_ing_with_rbutton = false;
-  // Set when a tab-closing handler succeeds. While active, subsequent messages
-  // in the same click sequence are swallowed to prevent Windows' consecutive
-  // DBLCLK messages from closing extra tabs or crashing vertical tabs.
-  static bool closing_tab_by_dblclk = false;
-  static bool closing_tab_by_middle = false;
-  static bool closing_tab_by_right = false;
+  // After a left double-click tab close, Windows still delivers the trailing
+  // WM_LBUTTONUP of that gesture. Swallow that single UP only.
+  // A sticky flag until the next LBUTTONDOWN is too wide: it can disrupt the
+  // next window action (close, minimize, caption drag) on Chrome's custom
+  // frame.
+  static bool swallow_next_lbutton_up = false;
+  // While set, ignore further LBUTTONDBLCLK on tabs so a burst of clicks
+  // cannot close more than one tab when Windows omits LBUTTONDOWN between
+  // consecutive DBLCLKs. Cleared on any new left-button down.
+  static ULONGLONG ignore_lbutton_dblclk_until = 0;
+  // Windows pairs two nearby clicks into one double-click even when the first
+  // landed on the new-tab button (or other non-tab chrome) and the second on
+  // a tab. Only treat DBLCLK as close when the preceding LBUTTONDOWN was on a
+  // tab body.
+  static bool last_lbutton_down_on_tab = false;
 
   switch (wParam) {
     case WM_MOUSEMOVE:
       HandleHoverTab(pmouse);
       return false;
     case WM_LBUTTONDOWN:
+    case WM_NCLBUTTONDOWN:
       CancelHoverTabTimer();
-      // Simply record the position of `LBUTTONDOWN` for drag detection
-      closing_tab_by_dblclk = false;
-      lbutton_down_point = pmouse->pt;
+      swallow_next_lbutton_up = false;
+      ignore_lbutton_dblclk_until = 0;
+      if (wParam == WM_LBUTTONDOWN) {
+        lbutton_down_point = pmouse->pt;
+        const auto hit = FindTabHitResult(pmouse->pt, false, true);
+        last_lbutton_down_on_tab = hit && !hit->on_close_button;
+      } else {
+        last_lbutton_down_on_tab = false;
+      }
       return false;
     case WM_MBUTTONDOWN:
+    case WM_NCMBUTTONDOWN:
       CancelHoverTabTimer();
-      closing_tab_by_middle = false;
       return false;
     case WM_RBUTTONDOWN:
+    case WM_NCRBUTTONDOWN:
       CancelHoverTabTimer();
-      closing_tab_by_right = false;
       return false;
     case WM_LBUTTONUP:
-      if (closing_tab_by_dblclk) {
+      if (swallow_next_lbutton_up) {
+        swallow_next_lbutton_up = false;
         return true;
       }
       if (HandleDrag(pmouse)) {
@@ -409,14 +432,16 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
       } else if (HandleBookmark(pmouse)) {
         return true;
       } else if (HandleCloseButton(pmouse)) {
-        closing_tab_by_dblclk = true;
+        return true;
+      }
+      return false;
+    case WM_NCLBUTTONUP:
+      if (swallow_next_lbutton_up) {
+        swallow_next_lbutton_up = false;
         return true;
       }
       return false;
     case WM_RBUTTONUP:
-      if (closing_tab_by_right) {
-        return true;
-      }
       if (wheel_tab_ing_with_rbutton) {
         // Swallow the first RBUTTONUP that follows a wheel-based tab switch to
         // suppress Chrome's context menu; the RBUTTONUP arrives after
@@ -424,7 +449,6 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
         wheel_tab_ing_with_rbutton = false;
         return true;
       } else if (HandleRightClick(pmouse)) {
-        closing_tab_by_right = true;
         return true;
       }
       return false;
@@ -444,35 +468,41 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
       }
       return false;
     case WM_LBUTTONDBLCLK:
-      if (closing_tab_by_dblclk) {
-        // Windows generates consecutive WM_LBUTTONDBLCLK for rapid clicks
-        // at the same position (no WM_LBUTTONDOWN in between). Swallow
-        // them to ensure one double-click gesture closes exactly one tab.
-        return true;
+      if (GetTickCount64() < ignore_lbutton_dblclk_until) {
+        // Burst DBLCLK only for tabs. Other clicks must pass through even
+        // inside the system double-click interval.
+        const auto hit = FindTabHitResult(pmouse->pt, false, true);
+        if (hit && !hit->on_close_button) {
+          swallow_next_lbutton_up = true;
+          return true;
+        }
+        ignore_lbutton_dblclk_until = 0;
+      }
+      // Require the first click of the double-click pair to be on a tab.
+      // Otherwise "new tab, then a quick click on a tab" becomes a system
+      // DBLCLK and would close that tab.
+      if (!last_lbutton_down_on_tab) {
+        return false;
       }
       if (HandleDoubleClick(pmouse)) {
         // Swallow the double-click so Chrome does not process it on the
         // now-destroyed tab (prevents crash on vertical tabs, issue #220).
-        // Also keep the flag active to suppress the following WM_LBUTTONUP
-        // (orphan UP in the DOWN-UP-DBLCLK-UP sequence) and any further
-        // consecutive DBLCLK messages from rapid clicking.
-        closing_tab_by_dblclk = true;
+        // Only the orphan UP of this DBLCLK-UP pair is suppressed; the next
+        // real left-button gesture must reach Chrome.
+        swallow_next_lbutton_up = true;
+        ignore_lbutton_dblclk_until =
+            GetTickCount64() + GetDoubleClickTime();
         return true;
       }
       return false;
     case WM_MBUTTONUP:
-      if (closing_tab_by_middle) {
-        return true;
-      }
       if (HandleMiddleClick(pmouse)) {
-        closing_tab_by_middle = true;
         return true;
       }
       return false;
     case WM_MBUTTONDBLCLK:
-      return closing_tab_by_middle;
     case WM_RBUTTONDBLCLK:
-      return closing_tab_by_right;
+      return false;
   }
   return false;
 }

--- a/src/tabbookmark.cc
+++ b/src/tabbookmark.cc
@@ -243,12 +243,6 @@ bool HandleDoubleClick(const MOUSEHOOKSTRUCT* pmouse) {
 
   const POINT pt = pmouse->pt;
   HWND hwnd = WindowFromPoint(pt);
-  // Commands target the browser frame; child HWNDs under the cursor are common.
-  if (hwnd) {
-    if (const HWND root = GetAncestor(hwnd, GA_ROOT)) {
-      hwnd = root;
-    }
-  }
   const auto hit = FindTabHitResult(pt, config.IsKeepLastTab(), true);
   if (!hit || hit->on_close_button) {
     return false;
@@ -381,20 +375,22 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
   PMOUSEHOOKSTRUCT pmouse = reinterpret_cast<PMOUSEHOOKSTRUCT>(lParam);
 
   static bool wheel_tab_ing_with_rbutton = false;
-  // After a left double-click tab close, Windows still delivers the trailing
-  // WM_LBUTTONUP of that gesture. Swallow that single UP only.
-  // A sticky flag until the next LBUTTONDOWN is too wide: it can disrupt the
-  // next window action (close, minimize, caption drag) on Chrome's custom
-  // frame.
-  static bool swallow_next_lbutton_up = false;
-  // While set, ignore further LBUTTONDBLCLK on tabs so a burst of clicks
-  // cannot close more than one tab when Windows omits LBUTTONDOWN between
-  // consecutive DBLCLKs. Cleared on any new left-button down.
-  static ULONGLONG ignore_lbutton_dblclk_until = 0;
-  // Windows pairs two nearby clicks into one double-click even when the first
-  // landed on the new-tab button (or other non-tab chrome) and the second on
-  // a tab. Only treat DBLCLK as close when the preceding LBUTTONDOWN was on a
-  // tab body.
+  // Set when a tab-closing handler succeeds. While active, subsequent messages
+  // in the same click sequence are swallowed to prevent Windows' consecutive
+  // DBLCLK messages from closing extra tabs or crashing vertical tabs.
+  // Cleared on the next button-down of the same button. The NC variants must
+  // clear too: caption gestures (drag, caption buttons) start with
+  // `WM_NCLBUTTONDOWN`, and a flag that only `WM_LBUTTONDOWN` clears outlives
+  // the close gesture and swallows the next gesture's `WM_LBUTTONUP` -- a dead
+  // first click on caption buttons, or a window that keeps dragging after
+  // release (#280).
+  static bool closing_tab_by_dblclk = false;
+  static bool closing_tab_by_middle = false;
+  static bool closing_tab_by_right = false;
+  // Windows pairs two nearby clicks into one double-click by time and distance
+  // alone, even when the first landed on the new-tab button (or other non-tab
+  // chrome) and the second on a tab that shifted under the cursor. Only treat
+  // DBLCLK as close when the preceding LBUTTONDOWN was on a tab body (#280).
   static bool last_lbutton_down_on_tab = false;
 
   switch (wParam) {
@@ -404,27 +400,31 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
     case WM_LBUTTONDOWN:
     case WM_NCLBUTTONDOWN:
       CancelHoverTabTimer();
-      swallow_next_lbutton_up = false;
-      ignore_lbutton_dblclk_until = 0;
+      closing_tab_by_dblclk = false;
+      last_lbutton_down_on_tab = false;
       if (wParam == WM_LBUTTONDOWN) {
+        // Simply record the position of `LBUTTONDOWN` for drag detection
         lbutton_down_point = pmouse->pt;
-        const auto hit = FindTabHitResult(pmouse->pt, false, true);
-        last_lbutton_down_on_tab = hit && !hit->on_close_button;
-      } else {
-        last_lbutton_down_on_tab = false;
+        // Gate on the config so clicks pay the UIA hit test only when
+        // double-click close can consume the result.
+        if (config.IsDoubleClickClose()) {
+          const auto hit = FindTabHitResult(pmouse->pt, false, true);
+          last_lbutton_down_on_tab = hit && !hit->on_close_button;
+        }
       }
       return false;
     case WM_MBUTTONDOWN:
     case WM_NCMBUTTONDOWN:
       CancelHoverTabTimer();
+      closing_tab_by_middle = false;
       return false;
     case WM_RBUTTONDOWN:
     case WM_NCRBUTTONDOWN:
       CancelHoverTabTimer();
+      closing_tab_by_right = false;
       return false;
     case WM_LBUTTONUP:
-      if (swallow_next_lbutton_up) {
-        swallow_next_lbutton_up = false;
+      if (closing_tab_by_dblclk) {
         return true;
       }
       if (HandleDrag(pmouse)) {
@@ -432,16 +432,20 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
       } else if (HandleBookmark(pmouse)) {
         return true;
       } else if (HandleCloseButton(pmouse)) {
+        closing_tab_by_dblclk = true;
         return true;
       }
       return false;
     case WM_NCLBUTTONUP:
-      if (swallow_next_lbutton_up) {
-        swallow_next_lbutton_up = false;
+      // The trailing UP of a double-click close arrives as an NC message when
+      // the close leaves caption area (empty tab strip) under the cursor;
+      // swallow it like the client-area UP. Any later NC UP belongs to a new
+      // gesture whose button-down already cleared the flag.
+      return closing_tab_by_dblclk;
+    case WM_RBUTTONUP:
+      if (closing_tab_by_right) {
         return true;
       }
-      return false;
-    case WM_RBUTTONUP:
       if (wheel_tab_ing_with_rbutton) {
         // Swallow the first RBUTTONUP that follows a wheel-based tab switch to
         // suppress Chrome's context menu; the RBUTTONUP arrives after
@@ -449,6 +453,7 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
         wheel_tab_ing_with_rbutton = false;
         return true;
       } else if (HandleRightClick(pmouse)) {
+        closing_tab_by_right = true;
         return true;
       }
       return false;
@@ -468,15 +473,11 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
       }
       return false;
     case WM_LBUTTONDBLCLK:
-      if (GetTickCount64() < ignore_lbutton_dblclk_until) {
-        // Burst DBLCLK only for tabs. Other clicks must pass through even
-        // inside the system double-click interval.
-        const auto hit = FindTabHitResult(pmouse->pt, false, true);
-        if (hit && !hit->on_close_button) {
-          swallow_next_lbutton_up = true;
-          return true;
-        }
-        ignore_lbutton_dblclk_until = 0;
+      if (closing_tab_by_dblclk) {
+        // Windows generates consecutive WM_LBUTTONDBLCLK for rapid clicks
+        // at the same position (no WM_LBUTTONDOWN in between). Swallow
+        // them to ensure one double-click gesture closes exactly one tab.
+        return true;
       }
       // Require the first click of the double-click pair to be on a tab.
       // Otherwise "new tab, then a quick click on a tab" becomes a system
@@ -487,22 +488,26 @@ bool TabBookmarkMouseHandler(WPARAM wParam, LPARAM lParam) {
       if (HandleDoubleClick(pmouse)) {
         // Swallow the double-click so Chrome does not process it on the
         // now-destroyed tab (prevents crash on vertical tabs, issue #220).
-        // Only the orphan UP of this DBLCLK-UP pair is suppressed; the next
-        // real left-button gesture must reach Chrome.
-        swallow_next_lbutton_up = true;
-        ignore_lbutton_dblclk_until =
-            GetTickCount64() + GetDoubleClickTime();
+        // Also keep the flag active to suppress the following WM_LBUTTONUP
+        // (orphan UP in the DOWN-UP-DBLCLK-UP sequence) and any further
+        // consecutive DBLCLK messages from rapid clicking.
+        closing_tab_by_dblclk = true;
         return true;
       }
       return false;
     case WM_MBUTTONUP:
+      if (closing_tab_by_middle) {
+        return true;
+      }
       if (HandleMiddleClick(pmouse)) {
+        closing_tab_by_middle = true;
         return true;
       }
       return false;
     case WM_MBUTTONDBLCLK:
+      return closing_tab_by_middle;
     case WM_RBUTTONDBLCLK:
-      return false;
+      return closing_tab_by_right;
   }
   return false;
 }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -229,12 +229,14 @@ void ExecuteCommand(int id, HWND hwnd) {
   if (hwnd == 0) {
     hwnd = GetForegroundWindow();
   }
+  // A null hwnd would turn the PostMessage below into a thread message.
+  if (!hwnd) {
+    return;
+  }
   // Browser commands are window-scoped. Callers often pass the HWND under the
   // cursor (child widget / render host); route to the top-level frame.
-  if (hwnd) {
-    if (const HWND root = ::GetAncestor(hwnd, GA_ROOT)) {
-      hwnd = root;
-    }
+  if (const HWND root = ::GetAncestor(hwnd, GA_ROOT)) {
+    hwnd = root;
   }
   // Post, do not Send: frequently called from the UI-thread mouse hook
   // (double-click close). A synchronous SendMessageTimeout can re-enter

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -229,10 +229,18 @@ void ExecuteCommand(int id, HWND hwnd) {
   if (hwnd == 0) {
     hwnd = GetForegroundWindow();
   }
-  // hwnd = GetTopWnd(hwnd);
-  // hwnd = GetForegroundWindow();
-  // PostMessage(hwnd, WM_SYSCOMMAND, id, 0);
-  ::SendMessageTimeoutW(hwnd, WM_SYSCOMMAND, id, 0, 0, 1000, 0);
+  // Browser commands are window-scoped. Callers often pass the HWND under the
+  // cursor (child widget / render host); route to the top-level frame.
+  if (hwnd) {
+    if (const HWND root = ::GetAncestor(hwnd, GA_ROOT)) {
+      hwnd = root;
+    }
+  }
+  // Post, do not Send: frequently called from the UI-thread mouse hook
+  // (double-click close). A synchronous SendMessageTimeout can re-enter
+  // Chrome while the hook is still on the stack and break the next
+  // window gesture after close.
+  ::PostMessageW(hwnd, WM_SYSCOMMAND, id, 0);
 }
 
 void LaunchCommands(const std::wstring& get_commands) {


### PR DESCRIPTION
## Summary

After double-click-to-close is enabled, two related mis-gestures can occur:

1. After closing a tab with a double-click, some follow-up window actions
   misbehave. Not every left click fails. For example:
   - The first click on close or minimize may do nothing
   - Dragging the window can keep moving after the mouse button is released

2. After clicking the new-tab button, a quick left click on a tab can close
   that tab. Windows still reports a double-click when the first click was
   on non-tab chrome and the second landed on a tab.

## Root cause

1. After a successful double-click close, a sticky `closing_tab_by_dblclk`
   flag stayed set until the next `WM_LBUTTONDOWN`. While set, the mouse
   hook swallowed follow-up messages too broadly, beyond the trailing
   message of the double-click gesture. That can disrupt the next window
   action, including close, minimize, and caption drag on Chrome's custom
   frame.

2. `ExecuteCommand` used synchronous `SendMessageTimeout` from the
   UI-thread mouse hook. Re-entering Chrome while the hook was still on
   the stack can also break the next interaction after close. The HWND
   under the cursor is often a child widget, not the browser frame.

3. Double-click close only checked whether the current `WM_LBUTTONDBLCLK`
   hit a tab. Windows pairs two nearby clicks by time and distance only,
   so "new tab, then a quick click on a tab" becomes a system double-click
   and was treated as close.

## Fix

- Swallow only the single trailing `WM_LBUTTONUP` / `WM_NCLBUTTONUP` of
  the double-click close gesture.
- Limit burst-`DBLCLK` suppression to hits on tabs, for one system
  double-click interval.
- Drop the sticky middle/right swallow flags that were not needed for
  that contract.
- Route `ExecuteCommand` to the top-level browser HWND and post
  `WM_SYSCOMMAND` instead of sending it synchronously from the hook.
- Close on double-click only when the preceding `WM_LBUTTONDOWN` was also
  on a tab body (not the new-tab button or other non-tab chrome).

## Testing

- Built successfully with `xmake -y` (release x64).
- Multi-tab window: double-click to close one tab, then click close or
  minimize immediately; the first click is handled.
- After double-click close, drag the window; movement stops when the
  mouse button is released.
- Click the new-tab button, then quickly click a tab; the tab is not
  closed.

## Demo

https://github.com/user-attachments/assets/cd1dcf2e-d309-45c0-8c55-37d07232cbef


## Authorship

This change was written with **Grok Build** (AI-assisted).